### PR TITLE
added support for API 1.4.0

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: HealthBar
 main: HealthBar\Loader
-version: 1.0.0
-api: 1.0.0
+version: 1.0.1
+api: 1.4.0
 author: LegendOfMCPE
 website: https://github.com/LegendOfMCPE/HealthBar
 softdepend: EssentialsPE

--- a/src/HealthBar/EventHandler.php
+++ b/src/HealthBar/EventHandler.php
@@ -53,19 +53,4 @@ class EventHandler implements Listener{
             }
         }
     }
-
-    /**
-     * @param EntityDamageByEntityEvent $event
-     */
-    public function onAttack(EntityDamageByEntityEvent $event){
-        $entity = $event->getEntity();
-        if($entity instanceof Player){
-            if($entity->getServer()->getGamemodeFromString($entity->getGamemode()) === 1|3){
-                $event->setCancelled(true);
-            }else{
-                $health = $entity->getHealth() - $event->getFinalDamage();
-                $this->plugin->updateHealthBar($entity, $health);
-            }
-        }
-    }
 } 


### PR DESCRIPTION
API 1.4.0 removes the need to reference EntityDamageByEntityEvent.
